### PR TITLE
feat: add adsense block to layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Analytics } from "@vercel/analytics/next";
+import { AdPlaceholder } from "@/components/AdPlaceholder";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -30,6 +31,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         className={`${inter.className} min-h-screen flex flex-col bg-gray-50 text-gray-900 antialiased`}
       >
         <Header />
+        <AdPlaceholder slot="global-top" />
         <main className="flex-grow container mx-auto px-4 py-8">
           {children}
           <Analytics />


### PR DESCRIPTION
## Summary
- display Google AdSense block below header on every page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0dc85b4788333b8ed59217b158574